### PR TITLE
Use a glob that supports double-star.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ go get github.com/lxn/win
 go get golang.org/x/sys/windows
 go get github.com/atotto/clipboard
 go get github.com/miekg/dns
+go get github.com/bmatcuk/doublestar
 pip3 install -r requirements.txt
 cd impacket
 python setup.py install


### PR DESCRIPTION
This should fix the issues that we were seeing with the `find` command as well as actually make `**` patterns work as intended. It also gives the full relative path for any files that match the pattern rather than just the filenames without any additional information about where they live on disk (current behavior).